### PR TITLE
(feat) embed Perception Check feedback form

### DIFF
--- a/next-sitemap.config.js
+++ b/next-sitemap.config.js
@@ -3,6 +3,7 @@ module.exports = {
   siteUrl: "https://alexey-pelykh.com",
   output: "export",
   generateRobotsTxt: true,
+  exclude: ['/feedback*'],
   additionalPaths: async () => [{
     loc: "/resume.pdf",
   }],

--- a/src/app/feedback/page.tsx
+++ b/src/app/feedback/page.tsx
@@ -1,0 +1,15 @@
+import { Metadata } from 'next';
+import TallyEmbed from './tally-embed';
+
+export const metadata: Metadata = {
+  title: 'Feedback - Alexey Pelykh',
+  description: 'Quick feedback check — I want to know how I come across.',
+};
+
+export default function FeedbackPage() {
+  return (
+    <main className="container bg-white dark:bg-black mx-auto px-4 py-8">
+      <TallyEmbed />
+    </main>
+  );
+}

--- a/src/app/feedback/tally-embed.tsx
+++ b/src/app/feedback/tally-embed.tsx
@@ -1,0 +1,25 @@
+'use client';
+
+import Script from 'next/script';
+
+export default function TallyEmbed() {
+  return (
+    <>
+      <Script
+        src="https://tally.so/widgets/embed.js"
+        strategy="lazyOnload"
+        onLoad={() => {
+          (window as any).Tally?.loadEmbeds();
+        }}
+      />
+      <iframe
+        data-tally-src="https://tally.so/embed/obROxN?alignLeft=1&hideTitle=1&transparentBackground=1&dynamicHeight=1"
+        loading="lazy"
+        width="100%"
+        height="640"
+        title="Perception Check"
+        style={{ border: 'none' }}
+      />
+    </>
+  );
+}


### PR DESCRIPTION
## Summary

- Add `/feedback` page with embedded Tally form for Perception Check
- Exclude feedback route from sitemap (private form, direct link only)
- Use lazy loading for script and iframe

## Test plan

- [ ] `/feedback/` page loads and displays Tally form
- [ ] Form is functional (can fill and submit)
- [ ] Dark mode displays correctly (transparent background)
- [ ] Page not present in generated sitemap

Closes #14

🤖 Generated with [Claude Code](https://claude.com/claude-code)