### PR TITLE
(fix) deploy job runs on PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,6 +58,7 @@ jobs:
           path: ./out
 
   deploy:
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}


### PR DESCRIPTION
## Summary

- Add `if:` condition to deploy job to only run on pushes to main
- PRs now trigger build job only (for validation)

## Change

```yaml
deploy:
  if: github.event_name == 'push' && github.ref == 'refs/heads/main'
```

## Test plan

- [ ] This PR should only run the `build` job (not `deploy`)
- [ ] Merging to main should trigger both `build` and `deploy`

Closes #16

🤖 Generated with [Claude Code](https://claude.com/claude-code)