### PR TITLE
(chore) add ESLint to CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,9 @@ jobs:
           sudo apt-get install -y fonts-noto-color-emoji poppler-utils
           npm ci
 
+      - name: Lint
+        run: npm run lint
+
       - name: Fetch Data
         env:
           GITHUB_TOKEN: ${{ secrets.CONTRIBUTIONS_READER_GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- Adds ESLint linting step to CI workflow before build

## Work Item
Closes #11

## Changes
- Added `npm run lint` step to `.github/workflows/ci.yml` after dependency installation and before data fetch

## Test Plan
- [x] `npm run lint` passes locally (warnings only, no errors)
- [ ] CI workflow runs lint step successfully

---
🤖 Generated via /do command