### PR TITLE
(fix) use correct repository name in React keys for PR listings

### DIFF
--- a/src/app/open-source-contributions/[projectSlug]/page.tsx
+++ b/src/app/open-source-contributions/[projectSlug]/page.tsx
@@ -157,7 +157,7 @@ export default async function OpenSourceProjectPage(
                 url: pullRequestUrl,
               }) => (
                 <div
-                  key={`${repositories[0].name}-${pullRequestNumber}`}
+                  key={`${repositoryName}-${pullRequestNumber}`}
                   className="flex items-center justify-start mb-1"
                 >
                   <a

--- a/src/app/open-source-contributions/page.tsx
+++ b/src/app/open-source-contributions/page.tsx
@@ -167,7 +167,7 @@ export default async function OpenSourceConstributionsIndexPage() {
                       url: pullRequestUrl,
                     }) => (
                       <div
-                        key={`${repositories[0].name}-${pullRequestNumber}`}
+                        key={`${repositoryName}-${pullRequestNumber}`}
                         className="flex items-center justify-start mb-1"
                       >
                         <a


### PR DESCRIPTION
## Summary

Fixed React key bug where pull request items in multi-repository views used `repositories[0].name` instead of the current `repositoryName` loop variable.

## Work Item

Fixes #9

## Changes

- Fixed `src/app/open-source-contributions/[projectSlug]/page.tsx:160`: Changed key from `repositories[0].name` to `repositoryName`
- Fixed `src/app/open-source-contributions/page.tsx:170`: Same issue in the summary page

## Impact

Before: React reconciliation issues when navigating between repositories, potential incorrect DOM updates, unnecessary re-renders.

After: Unique keys per repository ensure correct React reconciliation.

## Test Plan

- [x] Build passes (`npm run build`)
- [x] Lint passes (`npm run lint`)
- [x] Verified remaining `repositories[0].name` usages are in single-repository branches (correct)

---
🤖 Generated with [Claude Code](https://claude.ai/code)