### PR TITLE
(chore) remove unused google-fonts dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,6 @@
         "@radix-ui/react-slot": "~1.2.3",
         "class-variance-authority": "~0.7.1",
         "clsx": "~2.1.1",
-        "google-fonts": "~1.0.0",
         "lucide-react": "~0.540.0",
         "next": "~15.4.7",
         "puppeteer": "~24.16.2",
@@ -4155,12 +4154,6 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
-    },
-    "node_modules/google-fonts": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/google-fonts/-/google-fonts-1.0.0.tgz",
-      "integrity": "sha512-i3zzI697L9WdmnaSqYB5KYN2fqDpjfpW+UTBdzhmte6JSvS2GOczZZtfocpWhwPwPqsEAH76/46DrsnD5W6BQQ==",
-      "license": "MIT"
     },
     "node_modules/gopd": {
       "version": "1.2.0",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
     "@radix-ui/react-slot": "~1.2.3",
     "class-variance-authority": "~0.7.1",
     "clsx": "~2.1.1",
-    "google-fonts": "~1.0.0",
     "lucide-react": "~0.540.0",
     "next": "~15.4.7",
     "puppeteer": "~24.16.2",


### PR DESCRIPTION
## Summary
- Removes the unused `google-fonts` npm package from dependencies

## Investigation

The package was added in commit `3caeac70` "(fix) render-pdf in Docker" but was never actually imported or used. Docker-based testing confirmed:

| Test | google-fonts installed | PDF Size | Rendered Image |
|------|------------------------|----------|----------------|
| WITH | ✅ Yes | 222,371 bytes | Identical |
| WITHOUT | ❌ No | 222,371 bytes | Identical |

The actual Docker PDF fix was:
- System fonts via `apt-get install fonts-noto-color-emoji`
- Puppeteer launch args (`--no-sandbox`, `--disable-web-security`)
- Next.js font config (`display: "swap"`)

The `google-fonts` npm package only generates `<link>` tags for runtime font loading and has no install-time side effects.

## Test plan
- [x] Docker-based PDF rendering comparison (with vs without package)
- [ ] CI passes (PDF renders correctly, stays 1 page)

Closes #12

🤖 Generated with [Claude Code](https://claude.ai/claude-code)