### PR TITLE
(fix) add defensive null checks for project slug lookups

### DIFF
--- a/src/app/open-source-contributions/[projectSlug]/page.tsx
+++ b/src/app/open-source-contributions/[projectSlug]/page.tsx
@@ -1,6 +1,7 @@
 import { Metadata } from "next";
 import Image from "next/image";
 import Link from "next/link";
+import { notFound } from "next/navigation";
 import fs from "node:fs/promises";
 import path from "node:path";
 import githubMarkWhite from "../../github-mark-white.svg";
@@ -21,12 +22,16 @@ export async function generateMetadata(
     "utf-8",
   ).then(JSON.parse);
 
-  const { title } = openSourceContributions.projects.find(
-    (project) => project.slug === projectSlug,
-  )!;
+  const project = openSourceContributions.projects.find(
+    (p) => p.slug === projectSlug,
+  );
+
+  if (!project) {
+    return {};
+  }
 
   return {
-    title: `Alexey Pelykh - Open Source Contributions - ${title}`,
+    title: `Alexey Pelykh - Open Source Contributions - ${project.title}`,
     description: "Software architect | Solving challenges | Engineer of innovation | Actualizer of crazy ideas",
   };
 }
@@ -45,9 +50,15 @@ export default async function OpenSourceProjectPage(
     "utf-8",
   ).then(JSON.parse);
 
-  const { title, description, url, repositories } = openSourceContributions.projects.find(
-    (project) => project.slug === projectSlug,
-  )!;
+  const project = openSourceContributions.projects.find(
+    (p) => p.slug === projectSlug,
+  );
+
+  if (!project) {
+    notFound();
+  }
+
+  const { title, description, url, repositories } = project;
 
   return (
     <main className="container bg-white dark:bg-black mx-auto px-4 py-8">


### PR DESCRIPTION
## Summary

- Replace non-null assertions (`!`) with defensive null checks when looking up projects by slug in the open-source contributions detail page
- `generateMetadata` now returns empty metadata for invalid slugs instead of crashing
- Page component now calls `notFound()` for invalid slugs, returning a proper 404

Closes #10

## Test plan

- [ ] Build passes (`npm run build`)
- [ ] Navigate to a valid project slug — page renders correctly
- [ ] Navigate to an invalid project slug — shows 404 page instead of crash

🤖 Generated with [Claude Code](https://claude.com/claude-code)