### PR TITLE
(feat) add RSS feed for blog

### DIFF
--- a/generate-feed.js
+++ b/generate-feed.js
@@ -1,0 +1,86 @@
+const fs = require("node:fs");
+const path = require("node:path");
+const matter = require("gray-matter");
+
+const SITE_URL = "https://alexey-pelykh.com";
+const CONTENT_DIR = path.join(__dirname, "src", "content", "blog");
+const OUT_DIR = path.join(__dirname, "out", "blog");
+
+function escapeXml(str) {
+  return str
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&apos;");
+}
+
+function toRfc822(dateStr) {
+  return new Date(dateStr).toUTCString();
+}
+
+function getAllPosts() {
+  let entries;
+  try {
+    entries = fs.readdirSync(CONTENT_DIR);
+  } catch {
+    return [];
+  }
+
+  const files = entries.filter(
+    (f) => f.endsWith(".md") || f.endsWith(".mdx"),
+  );
+
+  const posts = files.map((filename) => {
+    const filePath = path.join(CONTENT_DIR, filename);
+    const raw = fs.readFileSync(filePath, "utf-8");
+    const { data } = matter(raw);
+
+    return {
+      title: data.title,
+      slug: data.slug,
+      date: data.date,
+      excerpt: data.excerpt,
+    };
+  });
+
+  return posts.sort(
+    (a, b) => new Date(b.date).getTime() - new Date(a.date).getTime(),
+  );
+}
+
+function generateRss(posts) {
+  const items = posts
+    .map(
+      (post) => `    <item>
+      <title>${escapeXml(post.title)}</title>
+      <link>${SITE_URL}/blog/${post.slug}</link>
+      <guid>${SITE_URL}/blog/${post.slug}</guid>
+      <description>${escapeXml(post.excerpt)}</description>
+      <pubDate>${toRfc822(post.date)}</pubDate>
+    </item>`,
+    )
+    .join("\n");
+
+  return `<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
+  <channel>
+    <title>Alexey Pelykh - Blog</title>
+    <link>${SITE_URL}/blog</link>
+    <description>Technical blog by Alexey Pelykh</description>
+    <language>en</language>
+    <atom:link href="${SITE_URL}/blog/feed.xml" rel="self" type="application/rss+xml"/>
+${items}
+  </channel>
+</rss>
+`;
+}
+
+const posts = getAllPosts();
+if (!fs.existsSync(OUT_DIR)) {
+  fs.mkdirSync(OUT_DIR, { recursive: true });
+}
+
+const feedPath = path.join(OUT_DIR, "feed.xml");
+fs.writeFileSync(feedPath, generateRss(posts), "utf-8");
+console.log(`Generated: ${feedPath} (${posts.length} posts)`);

--- a/package-lock.json
+++ b/package-lock.json
@@ -3021,7 +3021,6 @@
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
       "integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -3927,7 +3926,6 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
       "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
-      "dev": true,
       "license": "BSD-2-Clause",
       "bin": {
         "esparse": "bin/esparse.js",
@@ -7013,7 +7011,6 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/mz": {

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "retrieve-open-source-contributions": "mkdir -p data && cd data && node ../retrieve-open-source-contributions.js",
     "render-pdf": "node render-pdf.js",
     "render-screenshots": "node render-screenshots.js",
-    "copy-assets": "npm run render-pdf && cp gen/resume.pdf out/resume.pdf"
+    "generate-feed": "node generate-feed.js",
+    "copy-assets": "npm run render-pdf && cp gen/resume.pdf out/resume.pdf && npm run generate-feed"
   },
   "engines": {
     "node": "~22.18.0"

--- a/src/app/blog/layout.tsx
+++ b/src/app/blog/layout.tsx
@@ -1,0 +1,17 @@
+import { Metadata } from "next";
+
+export const metadata: Metadata = {
+  alternates: {
+    types: {
+      "application/rss+xml": "/blog/feed.xml",
+    },
+  },
+};
+
+export default function BlogLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return children;
+}


### PR DESCRIPTION
## Summary

- Generate RSS 2.0 feed at build time from blog post frontmatter
- Output at `out/blog/feed.xml` via `generate-feed.js` script
- Add `<link rel="alternate" type="application/rss+xml">` to blog pages via blog layout metadata
- Integrate feed generation into `copy-assets` build step

## Test plan

- [ ] `npm run build && npm run generate-feed` produces valid RSS 2.0 XML at `out/blog/feed.xml`
- [ ] Feed contains all blog posts with correct title, link, description, and pubDate
- [ ] Blog page HTML includes `<link rel="alternate" type="application/rss+xml" href="/blog/feed.xml"/>`
- [ ] Feed validates against RSS spec (W3C Feed Validation Service)

Closes #29

🤖 Generated with [Claude Code](https://claude.com/claude-code)