### PR TITLE
(feat) add blog post pages (/blog/[slug])

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@next/third-parties": "~15.4.7",
         "@radix-ui/react-icons": "~1.3.2",
         "@radix-ui/react-slot": "~1.2.3",
+        "@tailwindcss/typography": "^0.5.19",
         "class-variance-authority": "~0.7.1",
         "clsx": "~2.1.1",
         "gray-matter": "^4.0.3",
@@ -1288,6 +1289,31 @@
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.8.0"
+      }
+    },
+    "node_modules/@tailwindcss/typography": {
+      "version": "0.5.19",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/typography/-/typography-0.5.19.tgz",
+      "integrity": "sha512-w31dd8HOx3k9vPtcQh5QHP9GwKcgbMp87j58qi6xgiBnFFtKEAgCWnDw4qUT8aHwkCp8bKvb/KGKWWHedP0AAg==",
+      "license": "MIT",
+      "dependencies": {
+        "postcss-selector-parser": "6.0.10"
+      },
+      "peerDependencies": {
+        "tailwindcss": ">=3.0.0 || insiders || >=4.0.0-alpha.20 || >=4.0.0-beta.1"
+      }
+    },
+    "node_modules/@tailwindcss/typography/node_modules/postcss-selector-parser": {
+      "version": "6.0.10",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.10.tgz",
+      "integrity": "sha512-IQ7TZdoaqbT+LCpShg46jnZVlhWD2w6iQYAcYXfHARZ7X1t/UGhhceQDs5X0cGqKvYlHNOuv7Oa1xmb0oQuA3w==",
+      "license": "MIT",
+      "dependencies": {
+        "cssesc": "^3.0.0",
+        "util-deprecate": "^1.0.2"
+      },
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/@tootallnate/quickjs-emscripten": {
@@ -3021,7 +3047,6 @@
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
       "integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -3927,7 +3952,6 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
       "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
-      "dev": true,
       "license": "BSD-2-Clause",
       "bin": {
         "esparse": "bin/esparse.js",
@@ -7013,7 +7037,6 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/mz": {

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "@next/third-parties": "~15.4.7",
     "@radix-ui/react-icons": "~1.3.2",
     "@radix-ui/react-slot": "~1.2.3",
+    "@tailwindcss/typography": "^0.5.19",
     "class-variance-authority": "~0.7.1",
     "clsx": "~2.1.1",
     "gray-matter": "^4.0.3",

--- a/src/app/blog/[slug]/page.tsx
+++ b/src/app/blog/[slug]/page.tsx
@@ -1,9 +1,11 @@
 import { Metadata } from "next";
+import Link from "next/link";
 import { notFound } from "next/navigation";
 import { getAllPosts, getPostBySlug, renderMarkdown } from "@/lib/blog";
 import { evaluate } from "@mdx-js/mdx";
 import * as runtime from "react/jsx-runtime";
 import remarkGfm from "remark-gfm";
+import { ArrowLeft } from "lucide-react";
 
 export async function generateMetadata({
   params,
@@ -52,13 +54,22 @@ export default async function BlogPostPage({
   }
 
   return (
-    <main className="container bg-white dark:bg-black mx-auto px-4 py-8 max-w-3xl">
+    <main className="container bg-white dark:bg-black mx-auto px-4 py-8 max-w-prose print:hidden">
+      <nav className="mb-8">
+        <Link
+          href="/"
+          className="inline-flex items-center gap-1 text-sm text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-300"
+        >
+          <ArrowLeft className="w-4 h-4" />
+          Back
+        </Link>
+      </nav>
       <article>
         <header className="mb-8">
           <h1 className="text-3xl font-bold text-gray-900 dark:text-gray-100 mb-2">
             {post.frontmatter.title}
           </h1>
-          <div className="flex items-center gap-4 text-sm text-gray-500 dark:text-gray-400">
+          <div className="flex flex-wrap items-center gap-x-4 gap-y-1 text-sm text-gray-500 dark:text-gray-400">
             <time dateTime={post.frontmatter.date}>
               {new Date(post.frontmatter.date).toLocaleDateString("en-US", {
                 year: "numeric",
@@ -69,7 +80,7 @@ export default async function BlogPostPage({
             <span>{post.frontmatter.readingTime} min read</span>
           </div>
           {post.frontmatter.tags.length > 0 && (
-            <div className="flex gap-2 mt-3">
+            <div className="flex flex-wrap gap-2 mt-3">
               {post.frontmatter.tags.map((tag) => (
                 <span
                   key={tag}

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -18,6 +18,6 @@ const config: Config = {
       },
     },
   },
-  plugins: [require("tailwindcss-animate")],
+  plugins: [require("tailwindcss-animate"), require("@tailwindcss/typography")],
 };
 export default config;


### PR DESCRIPTION
## Summary

Improves the blog post page (`/blog/[slug]/`) created in #34 (MDX pipeline) to meet the requirements of #26:

- **Typography**: Install `@tailwindcss/typography` and register the plugin so `prose`/`dark:prose-invert` classes actually style blog content (headings, lists, code blocks, blockquotes)
- **Reading width**: Switch from `max-w-3xl` (768px) to `max-w-prose` (~65ch) for comfortable reading as specified in the issue
- **Back navigation**: Add a "Back" link with arrow icon for navigating away from blog posts
- **Responsive**: Add `flex-wrap` to metadata and tag rows so they wrap properly on mobile
- **Print safety**: Add `print:hidden` to blog post pages to prevent interference with the 1-page PDF resume

Closes #26

## Test plan

- [ ] `/blog/hello-world/` renders with proper typography styling
- [ ] `/blog/mdx-example/` renders MDX content including inline JSX
- [ ] Post metadata (title, date, reading time, tags) displayed correctly
- [ ] Dark mode works on blog post pages
- [ ] Mobile layout wraps metadata and tags without overflow
- [ ] `npm run build` produces `out/blog/*/index.html` static files
- [ ] PDF resume is not affected (blog pages use `print:hidden`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)