### PR TITLE
Add reading-friendly typography for blog posts

### DIFF
--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -16,6 +16,38 @@ const config: Config = {
         "gradient-radial": "radial-gradient(var(--tw-gradient-stops))",
         "gradient-conic": "conic-gradient(from 180deg at 50% 50%, var(--tw-gradient-stops))",
       },
+      typography: {
+        DEFAULT: {
+          css: {
+            a: {
+              color: "rgb(37 99 235)", // text-blue-600
+              textDecoration: "none",
+              fontWeight: "inherit",
+              "&:hover": {
+                textDecoration: "underline",
+              },
+            },
+            code: {
+              backgroundColor: "rgb(243 244 246)", // bg-gray-100
+              borderRadius: "0.25rem",
+              padding: "0.125rem 0.375rem",
+              fontWeight: "500",
+              "&::before": { content: "none" },
+              "&::after": { content: "none" },
+            },
+          },
+        },
+        invert: {
+          css: {
+            a: {
+              color: "rgb(59 130 246)", // text-blue-500
+            },
+            code: {
+              backgroundColor: "rgb(31 41 55)", // bg-gray-800
+            },
+          },
+        },
+      },
     },
   },
   plugins: [require("tailwindcss-animate"), require("@tailwindcss/typography")],


### PR DESCRIPTION
## Summary

- Customize `@tailwindcss/typography` prose styles in `tailwind.config.ts` for brand consistency
- Link colors match site convention (blue-600 light / blue-500 dark, underline on hover)
- Inline code uses background color + padding instead of backtick quotes
- Dark mode support for both links and inline code

The `prose dark:prose-invert` classes were already applied to blog post content in a previous commit. The typography plugin was already installed. This PR adds the customization layer to match the site's existing visual language.

Closes #31

## Test plan

- [ ] Blog post typography renders readable headings, paragraphs, lists, blockquotes
- [ ] Links appear blue with underline on hover (matching site convention)
- [ ] Inline code has subtle background, no backtick quotes
- [ ] Dark mode toggles all typography correctly
- [ ] No horizontal overflow on mobile
- [ ] Build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)