### PR TITLE
Add per-post SEO metadata (OG, JSON-LD, canonical)

### DIFF
--- a/src/app/blog/[slug]/page.tsx
+++ b/src/app/blog/[slug]/page.tsx
@@ -13,6 +13,8 @@ import remarkGfm from "remark-gfm";
 import { ArrowLeft } from "lucide-react";
 import rehypePrettyCode from "rehype-pretty-code";
 
+const SITE_URL = "https://alexey-pelykh.com";
+
 export async function generateMetadata({
   params,
 }: {
@@ -25,12 +27,21 @@ export async function generateMetadata({
     return { title: "Post Not Found" };
   }
 
+  const canonicalUrl = `${SITE_URL}/blog/${post.frontmatter.slug}`;
+
   return {
     title: `${post.frontmatter.title} - Alexey Pelykh`,
     description: post.frontmatter.excerpt,
-    openGraph: post.frontmatter.image
-      ? { images: [post.frontmatter.image] }
-      : undefined,
+    alternates: {
+      canonical: canonicalUrl,
+    },
+    openGraph: {
+      title: post.frontmatter.title,
+      description: post.frontmatter.excerpt,
+      type: "article",
+      url: canonicalUrl,
+      ...(post.frontmatter.image ? { images: [post.frontmatter.image] } : {}),
+    },
   };
 }
 
@@ -60,8 +71,27 @@ export default async function BlogPostPage({
     renderedContent = <div dangerouslySetInnerHTML={{ __html: html }} />;
   }
 
+  const jsonLd = {
+    "@context": "https://schema.org",
+    "@type": "Article",
+    headline: post.frontmatter.title,
+    description: post.frontmatter.excerpt,
+    datePublished: post.frontmatter.date,
+    dateModified: post.frontmatter.date,
+    author: {
+      "@type": "Person",
+      name: "Alexey Pelykh",
+      url: SITE_URL,
+    },
+    ...(post.frontmatter.image ? { image: post.frontmatter.image } : {}),
+  };
+
   return (
     <main className="container bg-white dark:bg-black mx-auto px-4 py-8 max-w-prose print:hidden">
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
+      />
       <nav className="mb-8">
         <Link
           href="/"


### PR DESCRIPTION
## Summary

- Add OpenGraph meta tags (`og:title`, `og:description`, `og:type`, `og:url`, `og:image`) to each blog post page via Next.js Metadata API
- Add JSON-LD Article structured data (`application/ld+json`) with headline, author, datePublished, dateModified, description, and image
- Add `<link rel="canonical">` pointing to `https://alexey-pelykh.com/blog/[slug]` for cross-posting authority
- Sitemap auto-discovers blog routes from `out/` with no config changes needed (verified)

Closes #28

## Test plan

- [ ] Verify OG meta tags render in `<head>` for each blog post (inspect HTML source or use OG preview tool)
- [ ] Verify JSON-LD `application/ld+json` script tag is present with correct Article schema
- [ ] Verify `<link rel="canonical">` points to the correct `alexey-pelykh.com` URL
- [ ] Verify blog posts appear in generated sitemap (`sitemap-0.xml`)
- [ ] Build succeeds with `npm run build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)