### PR TITLE
Fix blog navigation destinations and add index nav

### DIFF
--- a/src/app/blog/[slug]/page.tsx
+++ b/src/app/blog/[slug]/page.tsx
@@ -94,11 +94,11 @@ export default async function BlogPostPage({
       />
       <nav className="mb-8">
         <Link
-          href="/"
+          href="/blog"
           className="inline-flex items-center gap-1 text-sm text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-300"
         >
           <ArrowLeft className="w-4 h-4" />
-          Back
+          Blog
         </Link>
       </nav>
       <article>

--- a/src/app/blog/page.tsx
+++ b/src/app/blog/page.tsx
@@ -1,6 +1,7 @@
 import { Metadata } from "next";
 import Link from "next/link";
 import { getAllPosts } from "@/lib/blog";
+import { ArrowLeft } from "lucide-react";
 
 export const metadata: Metadata = {
   title: "Blog - Alexey Pelykh",
@@ -12,6 +13,15 @@ export default async function BlogIndexPage() {
 
   return (
     <main className="container bg-white dark:bg-black mx-auto px-4 py-8 max-w-3xl">
+      <nav className="mb-8">
+        <Link
+          href="/"
+          className="inline-flex items-center gap-1 text-sm text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-300"
+        >
+          <ArrowLeft className="w-4 h-4" />
+          Home
+        </Link>
+      </nav>
       <h1 className="text-3xl font-bold text-gray-900 dark:text-gray-100 mb-8">
         Blog
       </h1>


### PR DESCRIPTION
## Summary

- Blog post: `← Back` (→ `/`) changed to `← Blog` (→ `/blog`) — links to blog index instead of homepage
- Blog index: Added `← Home` (→ `/`) nav — was a dead end with no navigation

Fixes three UX issues: wrong destination, misleading label, missing blog index navigation.

Closes #41

🤖 Generated with [Claude Code](https://claude.com/claude-code)