### PR TITLE
Add breadcrumb navigation with site identity to blog pages

### DIFF
--- a/src/app/blog/[slug]/page.tsx
+++ b/src/app/blog/[slug]/page.tsx
@@ -10,8 +10,8 @@ import {
 import { evaluate } from "@mdx-js/mdx";
 import * as runtime from "react/jsx-runtime";
 import remarkGfm from "remark-gfm";
-import { ArrowLeft } from "lucide-react";
 import rehypePrettyCode from "rehype-pretty-code";
+import { Breadcrumb } from "@/components/breadcrumb";
 
 const SITE_URL = "https://alexey-pelykh.com";
 
@@ -92,15 +92,10 @@ export default async function BlogPostPage({
         type="application/ld+json"
         dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
       />
-      <nav className="mb-8">
-        <Link
-          href="/blog"
-          className="inline-flex items-center gap-1 text-sm text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-300"
-        >
-          <ArrowLeft className="w-4 h-4" />
-          Blog
-        </Link>
-      </nav>
+      <Breadcrumb
+        items={[{ label: "Blog", href: "/blog" }]}
+        current={post.frontmatter.title}
+      />
       <article>
         <header className="mb-8">
           <h1 className="text-3xl font-bold text-gray-900 dark:text-gray-100 mb-2">

--- a/src/app/blog/page.tsx
+++ b/src/app/blog/page.tsx
@@ -1,7 +1,7 @@
 import { Metadata } from "next";
 import Link from "next/link";
 import { getAllPosts } from "@/lib/blog";
-import { ArrowLeft } from "lucide-react";
+import { Breadcrumb } from "@/components/breadcrumb";
 
 export const metadata: Metadata = {
   title: "Blog - Alexey Pelykh",
@@ -13,15 +13,7 @@ export default async function BlogIndexPage() {
 
   return (
     <main className="container bg-white dark:bg-black mx-auto px-4 py-8 max-w-3xl">
-      <nav className="mb-8">
-        <Link
-          href="/"
-          className="inline-flex items-center gap-1 text-sm text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-300"
-        >
-          <ArrowLeft className="w-4 h-4" />
-          Home
-        </Link>
-      </nav>
+      <Breadcrumb items={[]} current="Blog" />
       <h1 className="text-3xl font-bold text-gray-900 dark:text-gray-100 mb-8">
         Blog
       </h1>

--- a/src/components/breadcrumb.tsx
+++ b/src/components/breadcrumb.tsx
@@ -1,0 +1,62 @@
+import { Fragment } from "react";
+import Link from "next/link";
+import { ChevronRight } from "lucide-react";
+
+const SITE_NAME = "Alexey Pelykh";
+
+interface BreadcrumbItem {
+  label: string;
+  href: string;
+}
+
+export function Breadcrumb({
+  items,
+  current,
+}: {
+  items: BreadcrumbItem[];
+  current: string;
+}) {
+  return (
+    <nav className="mb-8 print:hidden" aria-label="Breadcrumb">
+      <ol className="flex items-center gap-1.5 text-sm text-gray-500 dark:text-gray-400">
+        <li>
+          <Link
+            href="/"
+            className="hover:text-gray-700 dark:hover:text-gray-300 transition-colors"
+          >
+            {SITE_NAME}
+          </Link>
+        </li>
+        {items.map((item) => (
+          <Fragment key={item.href}>
+            <li
+              className="text-gray-400 dark:text-gray-500"
+              aria-hidden="true"
+            >
+              <ChevronRight className="w-3 h-3" />
+            </li>
+            <li>
+              <Link
+                href={item.href}
+                className="hover:text-gray-700 dark:hover:text-gray-300 transition-colors"
+              >
+                {item.label}
+              </Link>
+            </li>
+          </Fragment>
+        ))}
+        <li className="text-gray-400 dark:text-gray-500" aria-hidden="true">
+          <ChevronRight className="w-3 h-3" />
+        </li>
+        <li>
+          <span
+            className="text-gray-700 dark:text-gray-300"
+            aria-current="page"
+          >
+            {current}
+          </span>
+        </li>
+      </ol>
+    </nav>
+  );
+}


### PR DESCRIPTION
## Summary

- Replace back-arrow links (`← Home`, `← Blog`) with semantic breadcrumbs (`Alexey Pelykh › Blog`) on blog index and post pages
- Gives readers arriving from search engines or shared links immediate site identity context
- Uses semantic `<ol>` with `aria-label="Breadcrumb"`, chevron separators via lucide-react `ChevronRight`

## Test plan

- [ ] Blog index (`/blog`) shows `Alexey Pelykh › Blog` with name linking to `/`
- [ ] Blog post (`/blog/slug/`) shows `Alexey Pelykh › Blog` with name linking to `/` and Blog linking to `/blog`
- [ ] Breadcrumbs hidden in print (`print:hidden`)
- [ ] Dark mode colors correct
- [ ] Build passes (static export)

🤖 Generated with [Claude Code](https://claude.com/claude-code)