### PR TITLE
Add blog post: The x20 Is Literal

### DIFF
--- a/src/content/blog/the-x20-is-literal.md
+++ b/src/content/blog/the-x20-is-literal.md
@@ -1,0 +1,62 @@
+---
+title: "The x20 Is Literal: What a Day on Claude Code API Actually Costs"
+slug: the-x20-is-literal
+date: "2026-02-17"
+excerpt: "I ran Claude Code on the API for a day instead of the Max subscription. The x20 multiplier in the plan name? Not marketing. Actual math."
+pillar: industry-commentary
+tags:
+  - AI
+  - Claude Code
+  - Developer Tools
+  - Cost Analysis
+---
+
+## The Experiment
+
+I use Claude Code daily. It's my primary coding environment - not a novelty, not a side tool, the main event. Most days I'm on the Max subscription at $200/month, which Anthropic labels "Max x20" on account of the 20x usage allowance versus the Pro plan.
+
+One day I decided to see what that same usage pattern would cost at API rates. Not a benchmark. Not an optimized test. Just a normal working day - debugging, refactoring, writing new features, reviewing code - with the API meter running instead of the subscription.
+
+The result: roughly $200 in API costs. In a single day.
+
+Multiply that by 20 working days in a month, and you land somewhere around $4,000.
+
+The $200/month subscription covers the same usage. The x20 in the plan name isn't marketing. It's arithmetic.
+
+## The Numbers
+
+Let me be direct about what "normal usage" means here. This wasn't an attempt to stress-test the system or run up a tab. This was:
+
+- Iterating on a codebase with frequent back-and-forth
+- Asking Claude to read files, understand context, propose changes
+- Running through debugging cycles where context windows fill up
+- Code review passes with detailed feedback
+- Occasional "explain this architecture to me" sessions
+
+The kind of day where Claude Code earns its keep. Not light usage, but not adversarial either. The way a developer actually works when AI assistance is integrated into their flow.
+
+At API rates, each interaction carries the full weight of input and output token pricing. Context windows for coding tasks aren't small - you're feeding in files, getting back modified files, maintaining conversation history. The tokens add up fast. Opus-level models, which Claude Code defaults to for complex tasks, are priced at the premium tier.
+
+A single deep debugging session - the kind where you're going back and forth for 30 minutes on a stubborn issue - can burn through tokens that cost $10-15 at API rates. Do a few of those in a day alongside regular coding, and $200 isn't a stretch. It's a Tuesday.
+
+## What This Actually Means
+
+If you're a developer who codes daily and you're paying API rates for Claude Code usage, you're overspending by an order of magnitude. That's not an exaggeration, it's the literal ratio baked into the subscription tier name.
+
+The inverse is also worth noting: Anthropic is subsidizing heavy users at a rate that seems unsustainable on the surface. A $200/month subscription covering $4,000/month in compute suggests either aggressive loss-leading to capture market share, or margins on the API side that are wider than they appear. Probably some of both.
+
+For the individual developer, the calculus is simple. If you use Claude Code more than one day a month at any serious intensity, the Max subscription pays for itself. By day two, you're in the black. By the end of the month, you've captured roughly 95% savings versus pay-as-you-go.
+
+## The Broader Pattern
+
+This pricing dynamic isn't unique to Anthropic, but the magnitude is notable. Most SaaS subscriptions offer maybe 2-3x value over pay-per-use alternatives. A 20x multiplier is a different category of incentive.
+
+It signals where the AI tooling market is heading: the companies that win developer adoption will be the ones that make cost a non-issue. When the subscription removes the cognitive tax of "is this prompt worth the tokens?" - when you stop self-censoring your usage because the meter is running - the tool becomes qualitatively different. You use it more freely. You try more things. You let it read entire codebases without flinching at the token count.
+
+That behavioral shift is what the subscription is really buying. Not just compute at a discount, but the removal of friction between you and the tool.
+
+## The Punchline
+
+The x20 in "Max x20" isn't a brand badge or a tier label. It's a confession, hiding in plain sight.
+
+If you code daily and you're not on the subscription, run the numbers on your API spend. You might find - as I did - that the multiplier is quite literal.


### PR DESCRIPTION
## Summary
- Adds new blog post analyzing Claude Code API costs vs Max subscription
- Based on real-world usage data showing the x20 multiplier is literal arithmetic
- Content pillar: industry-commentary

## Test plan
- [ ] Build succeeds with new blog post
- [ ] Blog post renders correctly at `/blog/the-x20-is-literal`
- [ ] Blog index page lists the new post
- [ ] Sitemap includes the new post URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)