### PR TITLE
(imp) homepage opening — Full-Spectrum Architect positioning

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -112,8 +112,8 @@ export default function HomePage() {
             </div>
           </div>
           <p className="mt-2 print:mt-1 text-gray-700 dark:text-gray-300 print:text-black">
-            👋 Hello there! I&apos;m Alexey and I started my software engineering journey more than 20 years ago.
-            The selected greatest and craziest adventures thus far are:
+            👋 Hello there! I&apos;m Alexey. 22 years building software. 14+ technology domains.
+            The selection below is what that range looks like in practice:
           </p>
           <ul className="mt-2 print:mt-1 text-gray-700 dark:text-gray-300 print:text-black list-disc ml-10 print:ml-5">
             <li>


### PR DESCRIPTION
## Summary

- Replace 20-year chronological framing with the Full-Spectrum Architect opening per BDR-001 (`brand/decisions/001-full-spectrum-architect.md` in HQ)
- New copy lifted verbatim from HQ canonical source `profiles/website.md` § Homepage > Opening (updated in alexey-pelykh/hq#184)
- Adventures list, headline subtitle, and closing strapline already aligned — no changes needed there

## Changes

`src/app/page.tsx` opening paragraph (lines 114-117):

\`\`\`diff
-            👋 Hello there! I'm Alexey and I started my software engineering journey more than 20 years ago.
-            The selected greatest and craziest adventures thus far are:
+            👋 Hello there! I'm Alexey. 22 years building software. 14+ technology domains.
+            The selection below is what that range looks like in practice:
\`\`\`

The bridge phrase reframes the adventures list as **range evidence** rather than a chronological story.

## Test plan

- [x] Lint passes (\`npm run lint\` — no warnings/errors)
- [x] Build passes (\`npm run build\` — static export + sitemap)
- [x] Local dev preview reviewed
- [ ] CI green (1-page PDF check + deploy)
- [ ] Live URL renders new opening: https://alexey-pelykh.com/

## Refs

- Closes alexey-pelykh/hq#185
- BDR-001: alexey-pelykh/hq's \`brand/decisions/001-full-spectrum-architect.md\`
- Predecessor: alexey-pelykh/hq#184 (canonical text)