### PR TITLE
(imp) homepage closing — drop pre-BDR-001 hedging

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -146,9 +146,6 @@ export default function HomePage() {
               CPU emulator for the company&apos;s security research enabling it to detect and verify the signatures and watermarks on the bootloader.
             </li>
           </ul>
-          <p className="mt-2 print:mt-1 text-gray-700 dark:text-gray-300 print:text-black">
-            My passion lies in the hands-on exploration of software engineering frontiers.
-          </p>
           <p className="mt-4 font-semibold text-gray-700 dark:text-gray-300 print:hidden">
             <span className="italic">Challenges welcomed. Complexity conquered.</span> 🚀
           </p>


### PR DESCRIPTION
## Summary

Removes the \`My passion lies in the hands-on exploration of software engineering frontiers.\` paragraph from \`src/app/page.tsx\`. Propagates the HQ spec change from [alexey-pelykh/hq#196](https://github.com/alexey-pelykh/hq/pull/196) (which closed [alexey-pelykh/hq#170](https://github.com/alexey-pelykh/hq/issues/170)).

The line was a pre-BDR-001 bridge between the adventures list and the strapline close. It reads as hedging under Core Voice standards — \`my passion lies in\` is the same passive-voice pattern hq#170 flagged on LinkedIn.

## Flow after the removal

\`\`\`
Opening greeting ("Hello there! 👋 I'm Alexey. 22 years…")
  ↓
Adventures list (bulleted evidence of range)
  ↓
Strapline close ("Challenges welcomed. Complexity conquered. 🚀")
\`\`\`

Strapline punches directly after the evidence. No filler.

## What stays

- Opening greeting — unchanged (website's dual-layer \`Hello there! 👋\` Obi-Wan reference retained per website's destination-committed surface latitude, per hq BDR-002 Cross-Surface Coherence Protocol)
- Adventures bulleted list — unchanged
- Strapline with 🚀 — unchanged (🚀 retained per website's dual-layer latitude; the LinkedIn equivalent uses no emoji per feed-surfaced Core Voice strictness)

## Diff

3 lines removed in \`src/app/page.tsx\`:

\`\`\`diff
-          <p className=\"mt-2 print:mt-1 text-gray-700 dark:text-gray-300 print:text-black\">
-            My passion lies in the hands-on exploration of software engineering frontiers.
-          </p>
\`\`\`

## HQ spec reference

\`profiles/website.md\` (in the HQ repo) post-merge:

> **Closing**: \"Challenges welcomed. Complexity conquered. 🚀\"

The pre-BDR-001 version had \`My passion lies in the hands-on exploration of software engineering frontiers. Challenges welcomed. Complexity conquered. 🚀\` — the hedging opener was dropped in hq#196 during the cross-surface reconciliation audit triggered by hq#170.

## Test plan

- [x] Paragraph removal is clean JSX deletion; no imports/logic changes
- [x] Neighboring \`<ul>\` and \`<p>\` (strapline) unchanged; vertical spacing handled by existing \`mt-4\` on the strapline paragraph
- [ ] CI passes (build + 1-page PDF validation)
- [ ] Deploy to GitHub Pages succeeds; live alexey-pelykh.com shows adventures list → strapline directly

🤖 Generated with [Claude Code](https://claude.com/claude-code)