### PR TITLE
(fix) typography: drop backtick glyphs around inline code

### DIFF
--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -32,9 +32,13 @@ const config: Config = {
               borderRadius: "0.25rem",
               padding: "0.125rem 0.375rem",
               fontWeight: "500",
-              "&::before": { content: "none" },
-              "&::after": { content: "none" },
             },
+            // Flat keys (NOT nested under `code`) so these MERGE INTO the typography
+            // plugin's own `code::before`/`code::after` defaults and override the backtick
+            // glyphs. The prior nested `code: { "&::before" }` form emitted a DUPLICATE
+            // rule the plugin's default then won on source order — backticks stayed visible.
+            "code::before": { content: '""' },
+            "code::after": { content: '""' },
           },
         },
         invert: {


### PR DESCRIPTION
## Problem
The `@tailwindcss/typography` `prose` theme paints literal backtick glyphs around every inline `<code>` span via `code::before/::after { content: "\`" }`. On code-dense posts this is prominent (the latest teardown has 20 inline-code spans).

## Root cause
`tailwind.config.ts` already had an override, but nested under `code: { "&::before": { content: "none" } }`. The typography plugin treats that as a separate key from its own flat `code::before` default, so it emitted a **duplicate** rule — and the plugin's default came later in source order, winning the cascade. The override silently never worked (since 2026-02-16).

## Fix
Move the override to **flat** `code::before` / `code::after` keys so it merges into the plugin's own rule instead of duplicating it.

## Verification
Generated CSS from the repo config + a `prose`+`code` fixture: **zero** `content:"\`"` occurrences, with the `code` background/padding styling still present (not a degenerate empty build). Affects all posts site-wide (cleaner monospace inline code).

🤖 Generated with [Claude Code](https://claude.com/claude-code)