### PR TITLE
resume: drop "Brand Brain" product name from BAM row

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -357,7 +357,7 @@ export default function HomePage() {
             <p className="text-sm text-gray-500 print:hidden">Remote</p>
           </div>
           <div className="w-full md:w-2/3 print:w-3/5 print:text-sm">
-            Led the build of &ldquo;Brand Brain,&rdquo; an AI marketing-strategist SaaS, architecting a 25+ skill intelligence layer for brand-consistent content.
+            Led the build of an AI marketing-strategist SaaS, architecting a 25+ skill intelligence layer for brand-consistent content.
           </div>
         </div>
         <div className="mt-4 md:mt-2 print:mt-1 flex flex-col md:flex-row print:flex-row w-full gap-2 md:gap-0 print:gap-0">


### PR DESCRIPTION
Council-decided (brand + recruiter + legal, CONVERGENT 2026-07-07): drop the proprietary product name "Brand Brain" from public brand copy.

- **Brand + recruiter (both High):** zero external recognition value (obscure, decommissioned product); credibility lives in the role + technical substance, which stay intact.
- **Legal:** no barrier to dropping; naming a public former product is safe either way, but dropping shrinks the searchable tie to a company with a dormant receivable.
- Matches the 2026-05-18 precedent that already dropped it from the Toptal profile.

BAM row now: *"Led the build of an AI marketing-strategist SaaS, architecting a 25+ skill intelligence layer for brand-consistent content."*

Verified locally: 1 page, 0 occurrences of the product name.

🤖 Generated with [Claude Code](https://claude.com/claude-code)