### PR TITLE
(content) oca-review: integrate governance verdict with named power map

### DIFF
--- a/src/content/blog/oca-review-independence.md
+++ b/src/content/blog/oca-review-independence.md
@@ -2,14 +2,15 @@
 title: "How Communal Is OCA Review, Really?"
 slug: oca-review-independence
 date: "2026-07-09"
-excerpt: "OCA's merge bot doesn't count approvals — so I measured who actually reviews the code across 68,000 merged pull requests. Five companies wrote nearly half of it, and the biggest self-reviews two-thirds of its own work. The mechanism is measurable. The motive is not."
+excerpt: "OCA's merge bot never counts approvals, so its review norm is unenforced. Across 68,000 merged pull requests: five companies hold the keys, they review much of their own work, and independent review has thinned to a coin flip. Concentrated and unenforced — not captured."
 pillar: eng-economics
 tags:
   - Odoo
   - OCA
   - Open Source
-  - Code Review
   - Governance
+  - Code Review
+  - Data
 ---
 
 The Odoo Community Association ships one of the largest open-source libraries in business software. Thousands of addons, 261 repositories, tens of thousands of merged pull requests keeping accounting, inventory, HR, and e-commerce modules alive across dozens of Odoo versions.
@@ -26,7 +27,7 @@ It checks two things. That CI is green, and that the person triggering the merge
 
 It does not count approvals. There is an `APPROVALS_REQUIRED` setting, and it defaults to 2, but all it does is set a label. The merge task never reads it. The contributing guide asks for at least one review from someone with write access. That request lives in prose, not in code.
 
-Merge rights are not open to everyone. To trigger `/ocabot merge` at all, you need repo write access or you have to be a declared maintainer of every module the PR touches. Anyone else gets turned away. But for the people who clear that bar, the bot asks nothing about who reviewed the change. A maintainer can merge their own pull request into OCA with zero outside approval, and the tooling permits it. The question was never whether that is possible. It is how often it happens, and under what conditions.
+Merge rights are not open to everyone. To trigger `/ocabot merge` at all, you need repo write access or you have to be a declared maintainer of every module the PR touches. Anyone else gets turned away. But for the people who clear that bar, the bot asks nothing about who reviewed the change. A maintainer can merge their own pull request into OCA with zero outside approval, and the tooling permits it. So OCA's review norm is a convention, not a gate. The question is how much the convention holds — and where it doesn't.
 
 ## What I measured
 
@@ -42,25 +43,31 @@ The full method and the code that produces every number are public. More on that
 
 ## A handful of companies hold the keys
 
-OCA's charter says its contributors take part as individuals. Count the merged code by company anyway, and the individualism is hard to find.
+OCA's charter says its contributors take part as individuals. Count the merged code by company anyway, and the individualism is hard to find. 634 companies have contributed. Five of them wrote almost half of everything.
 
-634 companies have contributed. Five of them wrote almost half of everything.
+| Company | Merged PRs | Self-review rate\* | On others' turf\*\* |
+|---|---|---|---|
+| Tecnativa | 10,148 | 66.7% | 5.8% |
+| ForgeFlow | 4,646 | 28.3% | 2.2% |
+| Akretion | 4,006 | 8.4% | 0.8% |
+| Camptocamp | 2,308 | 11.5% | 3.3% |
+| Acsone | 2,306 | 8.3% | 1.9% |
 
-| Company | Merged PRs |
-|---|---|
-| Tecnativa | 10,148 |
-| ForgeFlow | 4,646 |
-| Akretion | 4,006 |
-| Camptocamp | 2,308 |
-| Acsone | 2,306 |
+\* Share of the company's *reviewed* PRs approved only by its own people. \*\* Share of its own PRs merged with no outside review onto a module another company maintains.
 
-Tecnativa alone has authored more than 10,000 merged pull requests — over double the next contributor, and better than a fifth of every merge the analysis could trace to a company. The top five account for 48% of all authorship; six companies for half of it. On the review side it is just as concentrated: five companies cast 51% of every approval. Both Gini coefficients sit above 0.9, where 1.0 would mean a single company did everything. (Attribution is by GitHub organization name, and a few firms contribute under more than one, so these per-name totals run conservative.)
+Tecnativa authored more than 10,000 merged pull requests — over double the next contributor, and better than a fifth of every merge the analysis could trace to a company. The top five account for 48% of all authorship; six companies for half. Five companies cast 51% of every approval, and both Gini coefficients sit above 0.9, where 1.0 would mean one company did everything. (Attribution is by GitHub organization name, and a few firms contribute under more than one, so these per-name totals run conservative.)
 
-Concentration like this is normal for mature open source. It matters here for one reason: the companies most able to review their own work — the ones with the colleagues, the write access, and the maintainer seats — are the same handful producing most of the work. So do they?
+None of this is capture, and the last column is why. Tecnativa's two-thirds self-review looks alarming until you read across the row: only 5.8% of its merges land on a module anyone else maintains. Heavy self-review is what you get when a company reviews the modules it owns, not when it reaches onto someone else's. The rate is not even uniform. Camptocamp, just as large, stays near one in nine. Size lets a company review itself; it does not make it. Across the table the turf figure never leaves the low single digits. The heaviest self-reviewers are the heaviest maintainers, reviewing the modules they own. That is the governance model working as intended.
 
-## They review a lot of their own work
+## Most of it is legitimate maintenance
 
-Group every contributing company by how many distinct people it has sent to OCA, then ask: of the PRs that got any review, what share were approved only by the author's own colleagues?
+That "on others' turf" column is doing a lot of work. OCA grants module maintainers merge rights over the modules they maintain, and a company approving its own PR on a module it maintains is doing exactly what the model intends. So for every merge with no outside approval, I pulled the modules it touched and compared the author's company against each module's declared maintainers. Then I did it again at the exact merge commit of each PR, not today's manifest — so a company that became a maintainer later couldn't make its past self-reviews look independent.
+
+Across every no-outside-review merge, the split comes out around 37% on the company's own maintained modules, 50% on modules that declare no maintainer at all, and only about 14% on another company's declared turf. That 14% is the whole of what could even be called encroachment, and once maintainership is credited, no major contributor stands out. The self-review is real. It is mostly companies reviewing their own code.
+
+## Self-review scales with company size
+
+The named five are visible because they are big. Widen to all 634 companies and the same pull is a gradient. Group each by how many distinct people it has sent to OCA, then ask what share of its reviewed PRs were approved only by its own colleagues.
 
 | Company size | Self-reviewed share of reviewed PRs |
 |---|---|
@@ -70,37 +77,19 @@ Group every contributing company by how many distinct people it has sent to OCA,
 | 10–19 | 16.1% |
 | 20+ | 55.6% |
 
-The gradient is clean and it points one way. A one-person company cannot self-review — it has no colleague to approve the work. A large one can, and the larger it gets, the more of its own work it signs off internally. At the top of the scale, more than half of all reviewed changes never see an approver from outside the author's own payroll. These are floors, not ceilings: the unresolved fifth of reviewers never count as insiders, so the true rates only run higher.
+A one-person company cannot self-review; it has no colleague to approve the work. A large one can, and on average the larger it gets, the more of its own reviewed work it signs off internally, until past twenty people more than half of it never sees an outside approver. These are floors, not ceilings: the unresolved fifth of reviewers never count as insiders, so the true rates only run higher. Nothing here is a rule being broken. Every one of these merges cleared the bot. That is the point.
 
-Put the biggest name to it. Tecnativa self-reviews two-thirds of its reviewed pull requests. 66.7%. On its face, that is the capture story writing itself.
+## Independent review used to be the norm. Now it's a coin flip.
 
-It isn't. And the reason it isn't is the most important measurement here.
+If one measurement answers the headline, it is this one. In 2017, 67.5% of merged PRs had an approver from an outside company. That share slid through 2021, dropped sharply in 2022, and bottomed at 40.8% in 2023. It has recovered to 47.8% in 2025, but the norm it used to be is gone. (2026 is a partial year, left out of the trend.)
 
-## Most of it is legitimate maintenance
+Independent review was once how OCA worked, the clear majority of the time. For the last four years it has been a coin flip. And it thins fastest exactly where the code concentrates, in the handful of companies large enough to review their own.
 
-OCA grants module maintainers merge rights over the modules they maintain. A company approving its own PR on a module it maintains is doing exactly what the governance model intends. Calling that "capture" would be wrong.
-
-So I went down a level. For every merge with no outside approval, I pulled the specific modules it touched and compared the author's company against each module's declared maintainers. Then I did it again at the exact merge commit of each PR, not just today's manifest, so a company that became a maintainer later could not launder its history.
-
-The result splits three ways. Around 37% of no-outside-review merges are a company's own maintained modules. Around 50% touch modules that declare no maintainer at all. Only about 14% touch another company's declared turf.
-
-And once maintainership is credited, no single company stands out. The biggest, least of all. Of Tecnativa's 10,000-plus merges, just 5.8% land on modules another company maintains. Two-thirds self-reviewed, and almost none of it on anyone else's turf. That is not a company capturing other people's work. It is a company reviewing a very large amount of its own.
-
-## Independent review eroded, then partly recovered
-
-In 2017, 67.5% of merged PRs had an approver from an outside company. That share slid gradually through 2021, dropped sharply in 2022, and bottomed at 40.8% in 2023. It has climbed back since, to 47.8% in 2025. (2026 is only a partial year, so I am leaving its number out of the trend.)
-
-Independent review used to be the clear norm in OCA. For the last four years it has hovered near a coin flip.
-
-## What this says, and what it doesn't
+## What this measures, and what it doesn't
 
 This measures provenance. Who approved a change. It says nothing about the quality of the change, the intent behind it, or whether anyone pushed an agenda. A self-reviewed patch can be excellent. An independently-reviewed one can be junk. I am not claiming any company games review to serve itself, because this data cannot show that, and I will not dress it up as if it could.
 
 There is also what I could not see. I count formal approvals, not the comments and change-requests where plenty of real review happens. A change an outside engineer picked apart in comments, but never formally approved, still reads here as self-reviewed. Read these as rates of formal sign-off, not of every eyeball on the code.
-
-What it does show is structural, and it is enough on its own. A handful of companies hold most of the keys to OCA. They review much of their own work — legitimately, on modules they maintain — and OCA's independent-review norm is unenforced by the tooling. Nothing in the merge path would stop them if that work were someone else's.
-
-Whether that is fine, or a problem worth changing the merge bot over, is a governance question for OCA. This data doesn't answer it. It measures it.
 
 ## Why the code is public too
 
@@ -110,4 +99,4 @@ So the whole pipeline is open. Collection, company attribution, analysis, the ag
 
 [github.com/alexey-pelykh/oca-review-independence](https://github.com/alexey-pelykh/oca-review-independence)
 
-The keys to OCA sit with a handful of companies. They review a great deal of their own work, and the tooling would not stop them if that work were anyone else's. It mostly isn't — I checked. Independent review still holds across most of OCA, but it thins out exactly where the work concentrates. That is not an accusation. It is a measurement.
+So, how communal is OCA review, really? Communal by charter, not by code. A handful of companies hold the keys, and they review a great deal of their own work — legitimately, on the modules they maintain. But the merge bot never asks who reviewed a change, so the "at least one review" norm is a convention, not a gate, and independent review has thinned to a coin flip exactly where the work concentrates. Concentrated and unenforced, not captured. That is not an accusation. It is a measurement — of a communal norm that lives in prose, not in code, and has been eroding while nobody counted.


### PR DESCRIPTION
Rebuilds the live OCA review-independence post around the hybrid it was missing: the **named power map as evidence**, the **governance finding as the verdict**, integrated into one answer to the headline.

## What changed
- **Leaderboard → full 3-column table** (Merged PRs / self-review rate / on-others'-turf) — the reveal (Tecnativa self-reviews 66.7%) now lands in the table, not buried in prose.
- **Erosion section elevated + retitled** "Independent review used to be the norm. Now it's a coin flip." It opens "If one measurement answers the headline, it is this one" — the governance finding now carries the weight.
- **Dropped the "capture story writing itself" cliffhanger**; moved the "most important measurement" crown off the acquittal onto the erosion verdict.
- **Accusation-safety** (brand voice gate): replaced "launder its history" (crime verb on a named company); re-sequenced the 66.7% so a scanning reader meets it already framed as turf-not-capture.
- **Close integrates both**: "Communal by charter, not by code… Concentrated and unenforced, not captured."

## Gates
- Fact-check: every figure re-traced to a committed CSV cell; erosion shape verified against year-by-year data.
- Voice (brand-strategist): REVISE → all 4 must-fixes applied → measurement-not-accusation holds.

Net −11 lines (tighter). Text-only body per website convention.