### PR TITLE
(content) qontoctl-mcp: drop stale "just/now" recency framing

### DIFF
--- a/src/content/blog/qontoctl-and-the-official-qonto-mcp.md
+++ b/src/content/blog/qontoctl-and-the-official-qonto-mcp.md
@@ -16,7 +16,7 @@ tags:
 
 When I started QontoCtl, Qonto had an API and nothing around it - no CLI, no SDK, no AI integration. That gap was the whole reason the project existed.
 
-Part of that gap just closed. Qonto now ships an [official MCP server](https://docs.qonto.com/mcp/overview): hosted, free on every plan, and connectable in a tap from Claude, ChatGPT, Cursor, VS Code, and more. It's genuinely good. You log in with your Qonto account, and your assistant can read your transactions, draft invoices, manage cards and team members - all with a human approving anything sensitive in the Qonto app.
+Part of that gap has closed. Qonto ships an [official MCP server](https://docs.qonto.com/mcp/overview): hosted, free on every plan, and connectable in a tap from Claude, ChatGPT, Cursor, VS Code, and more. It's genuinely good. You log in with your Qonto account, and your assistant can read your transactions, draft invoices, manage cards and team members - all with a human approving anything sensitive in the Qonto app.
 
 So the obvious question, which I got within a day of it launching: **does QontoCtl still make sense?**
 


### PR DESCRIPTION
## What

Reword the opening of the QontoCtl-vs-official-MCP blog post to remove stale recency framing.

- `Part of that gap just closed. Qonto now ships an official MCP server` → `Part of that gap has closed. Qonto ships an official MCP server`

## Why

Qonto's official MCP launched **2026-06-16** (per planet-fintech.com + the `qonto/qonto-mcp-server` repo), ~1 month before this post's publish date (2026-07-15). "just closed" / "now ships" implied a this-week launch. The reworded copy is timeless (no recency claim) and stays accurate on reshare.

Single-line copy edit. No claims added or removed (the separately-flagged "free on every plan" line is untouched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)